### PR TITLE
(minor) should export utility functions from d3

### DIFF
--- a/cosmoz-chart.js
+++ b/cosmoz-chart.js
@@ -6,6 +6,9 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
  */
 import { bb } from 'billboard.js/src/core';
 
+export { format, utcFormat } from 'd3';
+export { schemePaired as defaultColorScheme } from 'd3-scale-chromatic';
+
 /**
  * Billboard.js configuration properties
  * @type {Array}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   },
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "billboard.js": "^1.9.3"
+    "billboard.js": "^1.9.3",
+    "d3": "^5.9.7",
+    "d3-scale-chromatic": "^1.3.3"
   },
   "devDependencies": {
     "@neovici/eslint-config": "github:neovici/eslint-config#semver:^1.0.0",


### PR DESCRIPTION
This way `cosmoz-frontend` can remove it's dependency on `d3`.