### PR TITLE
Overlapping labels test and revert of afterNextRender commit

### DIFF
--- a/cosmoz-chart.js
+++ b/cosmoz-chart.js
@@ -1,6 +1,4 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
-
 
 /**
  * billboard.js
@@ -129,7 +127,7 @@ class CosmozChart extends PolymerElement {
 	connectedCallback() {
 		super.connectedCallback();
 
-		afterNextRender(this, this.render);
+		this.render();
 	}
 
 	/**

--- a/test/cosmoz-chart_test.html
+++ b/test/cosmoz-chart_test.html
@@ -33,16 +33,12 @@
 		</test-fixture>
 
 		<script type="module">
-		import { tap } from '@polymer/iron-test-helpers/mock-interactions.js';
-		import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
-		import { upgradeDomTemplates } from './helpers/utils.js';
-
-		const nextRender = () => new Promise(resolve => afterNextRender(null, resolve));
-
+		import {tap} from '@polymer/iron-test-helpers/mock-interactions.js';
+		import {upgradeDomTemplates} from './helpers/utils.js';
 		upgradeDomTemplates();
 
 		describe('cosmoz-chart', () => {
-			it('draws a simple line chart', async () => {
+			it('draws a simple line chart', () => {
 				const element = fixture('BasicTestFixture', {
 					data: {
 						columns: [
@@ -58,14 +54,12 @@
 					}
 				});
 
-				await nextRender();
-
 				expect(element.querySelectorAll('.bb-legend-item text')).to.not.overlap();
 				expect(element.querySelector('.bb-line-data1')).to.exist;
 				expect(element.querySelectorAll('circle')).to.have.lengthOf(24);
 			});
 
-			it('configures axis', async () => {
+			it('configures axis', () => {
 				const element = fixture('BasicTestFixture', {
 					data: {
 						columns: [['data1', 10, 20, 30]]
@@ -84,13 +78,11 @@
 					line: {point: false}
 				});
 
-				await nextRender();
-
 				expect(window.getComputedStyle(element.querySelector('.bb-axis-x')).visibility).to.equal('hidden');
 				expect(Array.from(element.querySelectorAll('.bb-axis-y .tick')).map(i => i.textContent)).to.deep.equal(['8%', '14%', '20%', '26%', '32%']);
 			});
 
-			it('can receive whole configuration object', async () => {
+			it('can receive whole configuration object', () => {
 				const element = fixture('BasicTestFixture', {
 					data: {
 						columns: [['data1', 10, 20, 30]]
@@ -102,12 +94,10 @@
 					}
 				});
 
-				await nextRender();
-
 				expect(window.getComputedStyle(element.querySelector('.bb-axis-x')).visibility).to.equal('hidden');
 			});
 
-			it('individual prop configurations take precedence over [config]', async () => {
+			it('individual prop configurations take precedence over [config]', () => {
 				const element = fixture('BasicTestFixture', {
 					data: {
 						columns: [['data1', 10, 20, 30]]
@@ -123,12 +113,10 @@
 					line: {}
 				});
 
-				await nextRender();
-
 				expect(window.getComputedStyle(element.querySelector('.bb-axis-x')).visibility).to.equal('hidden');
 			});
 
-			it('updates the chart when the data changes', async () => {
+			it('updates the chart when the data changes', () => {
 				const element = fixture('BasicTestFixture', {
 					data: {
 						columns: [
@@ -136,8 +124,6 @@
 						]
 					}
 				});
-
-				await nextRender();
 
 				element.set('data', {
 					columns: [
@@ -151,14 +137,12 @@
 				expect(element.querySelectorAll('circle')).to.have.lengthOf(10);
 			});
 
-			it('updates the chart when the config changes', async () => {
+			it('updates the chart when the config changes', () => {
 				const element = fixture('BasicTestFixture', {
 					data: {
 						columns: [['data1', 10, 20, 30]]
 					}
 				});
-
-				await nextRender();
 
 				expect(window.getComputedStyle(element.querySelector('.bb-axis-x')).visibility).to.equal('visible');
 
@@ -213,7 +197,6 @@
 					}
 				});
 
-				await nextRender();
 				element.style.display = 'block';
 				element.chart.resize();
 

--- a/test/cosmoz-chart_test.html
+++ b/test/cosmoz-chart_test.html
@@ -26,6 +26,12 @@
 			</template>
 		</test-fixture>
 
+		<test-fixture id="HiddenTestFixture">
+			<template is="dom-template">
+					<cosmoz-chart style="display:none" data="[[data]]" config="[[config]]"></cosmoz-chart>
+			</template>
+		</test-fixture>
+
 		<script type="module">
 		import { tap } from '@polymer/iron-test-helpers/mock-interactions.js';
 		import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
@@ -40,15 +46,23 @@
 				const element = fixture('BasicTestFixture', {
 					data: {
 						columns: [
-							['data1', 1, 2, 3]
+							['data1', 1, 2, 3],
+							['data2', 1, 2, 3],
+							['data3', 1, 2, 3],
+							['data4', 1, 2, 3],
+							['data5', 1, 2, 3],
+							['data6', 1, 2, 3],
+							['data7', 1, 2, 3],
+							['data8', 1, 2, 3]
 						]
 					}
 				});
 
 				await nextRender();
 
+				expect(element.querySelectorAll('.bb-legend-item text')).to.not.overlap();
 				expect(element.querySelector('.bb-line-data1')).to.exist;
-				expect(element.querySelectorAll('circle')).to.have.lengthOf(3);
+				expect(element.querySelectorAll('circle')).to.have.lengthOf(24);
 			});
 
 			it('configures axis', async () => {
@@ -182,6 +196,32 @@
 			});
 		});
 
+		describe('known bugs', () => {
+			it('rendering while hidden causes legend items to overlap [#15]', async () => {
+				const element = fixture('HiddenTestFixture', {
+					data: {
+						columns: [
+							['data1', 1, 2, 3],
+							['data2', 1, 2, 3],
+							['data3', 1, 2, 3],
+							['data4', 1, 2, 3],
+							['data5', 1, 2, 3],
+							['data6', 1, 2, 3],
+							['data7', 1, 2, 3],
+							['data8', 1, 2, 3]
+						]
+					}
+				});
+
+				await nextRender();
+				element.style.display = 'block';
+				element.chart.resize();
+
+				expect(() => {
+					expect(element.querySelectorAll('.bb-legend-item text')).to.not.overlap();
+				}).to.throw();
+			});
+		});
 		</script>
 	</body>
 </html>

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -12,3 +12,30 @@ export const upgradeDomTemplates = () => {
 		};
 	});
 };
+
+const intersects = (el1, el2) => {
+	const r1 = el1.getBoundingClientRect(),
+		r2 = el2.getBoundingClientRect();
+
+	return r2.top >= r1.top && r2.top <= r1.bottom && (r2.left >= r1.left && r2.left <= r1.right)
+		|| r2.bottom >= r1.top && r2.bottom <= r1.bottom && (r2.left >= r1.left && r2.left <= r1.right)
+		|| r2.top >= r1.top && r2.top <= r1.bottom && (r2.right >= r1.left && r2.right <= r1.right)
+		|| r2.bottom >= r1.top && r2.bottom <= r1.bottom && (r2.right >= r1.left && r2.right <= r1.right);
+};
+
+const elementsOverlap = (element, index, elements) =>
+	elements.slice(0, index)
+		.concat(elements.slice(index + 1))
+		.some(otherElement => intersects(element, otherElement) || intersects(otherElement, element));
+
+/** @this chai.Assertion */
+const overlap = function () {
+	const obj = chai.util.flag(this, 'object');
+	this.assert(
+		Array.from(obj).some(elementsOverlap),
+		'expected elements to overlap',
+		'expected elements not to overlap',
+	);
+};
+
+chai.Assertion.addMethod('overlap', overlap);


### PR DESCRIPTION
Trying to fix https://github.com/Neovici/cosmoz-charts/issues/15 made apparent that `afterNextRender` adds unneeded complexity and does not solve anything. The use of `afterNextRender` is wrong [according to the Polymer documentation](https://polymer-library.polymer-project.org/2.0/api/namespaces/Polymer.RenderStatus#function-Polymer.RenderStatus.afterNextRender), as it's meant to be used to run non-render-critical code. Actually rendering the chart is very render-critical. :sweat_smile:

The stems from the billboard.js library so I will file a bug report there and mark this issue as a known bug for now.

Workaround:

call `chart.render()` when needed.