### PR TITLE
fix: resize glitch in flex layout

### DIFF
--- a/cosmoz-chart.js
+++ b/cosmoz-chart.js
@@ -45,9 +45,9 @@ const
 		}, [option]);
 
 		useEffect(() => {
-			const observer = new ResizeObserver(() => requestAnimationFrame(() => {
-				ref.chart.resize();
-			}));
+			const observer = new ResizeObserver(entries => requestAnimationFrame(() => ref.chart.resize({
+				width: entries[0]?.contentRect.width
+			})));
 			observer.observe(host);
 			return () => observer.unobserve(host);
 		}, []);


### PR DESCRIPTION
Due to a race-condition, the resize is called over and over again. Fixed
by using the resize observer information to explicitly set the desired
width of the chart.

Re https://neovici.slack.com/archives/C6LJQMJFM/p1637829262085800