### PR TITLE
fix: correct package name in changeset

### DIFF
--- a/.changeset/yummy-buses-spend.md
+++ b/.changeset/yummy-buses-spend.md
@@ -1,5 +1,5 @@
 ---
-'migrate-from-semantic-release': minor
+'@neovici/cosmoz-charts': minor
 ---
 
 Migrate from semantic-release to changesets for version management and release flows.


### PR DESCRIPTION
Fixes CI error from #265.

## Error
```
Error: Found changeset yummy-buses-spend for package migrate-from-semantic-release which is not in the workspace
```

## Fix
Changed package name in `.changeset/yummy-buses-spend.md`:
- From: `'migrate-from-semantic-release': minor`
- To: `'@neovici/cosmoz-charts': minor`

The package name must match the workspace package name from package.json.